### PR TITLE
Fix issue #64

### DIFF
--- a/git.ts
+++ b/git.ts
@@ -4,9 +4,9 @@
 // Last Change : 2024/09/29 00:24:42.
 // =============================================================================
 
-import * as path from "jsr:@std/path@1.0.7";
+import * as path from "jsr:@std/path@1.0.8";
 import { exists } from "jsr:@std/fs@1.0.5";
-import { TextLineStream } from "jsr:@std/streams@1.0.7";
+import { TextLineStream } from "jsr:@std/streams@1.0.8";
 
 /**
  * Git

--- a/git_test.ts
+++ b/git_test.ts
@@ -4,7 +4,7 @@
 // Last Change : 2024/06/30 12:59:58.
 // =============================================================================
 
-import { assertEquals } from "jsr:@std/assert@1.0.6";
+import { assertEquals } from "jsr:@std/assert@1.0.7";
 
 import { Git } from "./git.ts";
 

--- a/plugin.ts
+++ b/plugin.ts
@@ -1,7 +1,7 @@
 // =============================================================================
 // File        : plugin.ts
 // Author      : yukimemi
-// Last Change : 2024/10/26 13:31:55.
+// Last Change : 2024/11/02 15:33:48.
 // =============================================================================
 
 import * as fn from "jsr:@denops/std@7.3.0/function";
@@ -54,7 +54,7 @@ export class Plugin {
       logger().debug(`[create] set dst to ${p.plug.dst}`);
       p.info.dst = z.string().parse(await fn.expand(p.denops, p.plug.dst));
     } else {
-      const url = new URL(p.plug.url);
+      const url = new URL(p.info.url);
       p.info.dst = path.join(option.base, url.hostname, url.pathname);
     }
     p.info.clone = await p.is(p.info.clone);

--- a/plugin.ts
+++ b/plugin.ts
@@ -6,7 +6,7 @@
 
 import * as fn from "jsr:@denops/std@7.3.0/function";
 import * as op from "jsr:@denops/std@7.3.0/option";
-import * as path from "jsr:@std/path@1.0.7";
+import * as path from "jsr:@std/path@1.0.8";
 import type { Bool, Plug, PlugInfo, PlugOption } from "./types.ts";
 import type { Denops } from "jsr:@denops/std@7.3.0";
 import { Git } from "./git.ts";

--- a/plugin_test.ts
+++ b/plugin_test.ts
@@ -1,12 +1,12 @@
 // =============================================================================
 // File        : plugin_test.ts
 // Author      : yukimemi
-// Last Change : 2024/11/02 15:27:26.
+// Last Change : 2024/11/02 15:58:07.
 // =============================================================================
 
 import { Plugin } from "./plugin.ts";
-import { assertEquals } from "jsr:@std/assert";
-import { DenopsStub } from "jsr:@denops/test";
+import { assertEquals } from "jsr:@std/assert@1.0.7";
+import { DenopsStub } from "jsr:@denops/test@3.0.4";
 
 const createDenops = () => (
   new DenopsStub({

--- a/plugin_test.ts
+++ b/plugin_test.ts
@@ -1,0 +1,77 @@
+// =============================================================================
+// File        : plugin_test.ts
+// Author      : yukimemi
+// Last Change : 2024/11/02 15:27:26.
+// =============================================================================
+
+import { Plugin } from "./plugin.ts";
+import { assertEquals } from "jsr:@std/assert";
+import { DenopsStub } from "jsr:@denops/test";
+
+const createDenops = () => (
+  new DenopsStub({
+    call: (fn, ...args) => {
+      return Promise.resolve([fn, ...args]);
+    },
+  })
+);
+
+Deno.test({
+  name: "Create Plugin with full URL",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const denops = createDenops();
+    const plug = {
+      url: "https://github.com/vim-jp/vimdoc-ja",
+    };
+    const option = {
+      base: "/tmp",
+      debug: false,
+      profile: false,
+      logarg: [],
+    };
+    const plugin = await Plugin.create(denops, plug, option);
+    assertEquals(plugin.info.url, "https://github.com/vim-jp/vimdoc-ja");
+  },
+});
+
+Deno.test({
+  name: "Create Plugin with shorthand URL",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const denops = createDenops();
+    const plug = {
+      url: "vim-jp/vimdoc-ja",
+    };
+    const option = {
+      base: "/tmp",
+      debug: false,
+      profile: false,
+      logarg: [],
+    };
+    const plugin = await Plugin.create(denops, plug, option);
+    assertEquals(plugin.info.url, "https://github.com/vim-jp/vimdoc-ja");
+  },
+});
+
+Deno.test({
+  name: "Create Plugin with git URL",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const denops = createDenops();
+    const plug = {
+      url: "git://github.com/vim-jp/vimdoc-ja",
+    };
+    const option = {
+      base: "/tmp",
+      debug: false,
+      profile: false,
+      logarg: [],
+    };
+    const plugin = await Plugin.create(denops, plug, option);
+    assertEquals(plugin.info.url, "git://github.com/vim-jp/vimdoc-ja");
+  },
+});

--- a/util.ts
+++ b/util.ts
@@ -7,7 +7,7 @@
 import * as fn from "jsr:@denops/std@7.3.0/function";
 import * as fs from "jsr:@std/fs@1.0.5";
 import type { Denops } from "jsr:@denops/std@7.3.0";
-import { dirname, extname } from "jsr:@std/path@1.0.7";
+import { dirname, extname } from "jsr:@std/path@1.0.8";
 import { echo, echoerr, execute } from "jsr:@denops/std@7.3.0/helper";
 import { logger } from "./logger.ts";
 import { z } from "npm:zod@3.23.8";

--- a/util_test.ts
+++ b/util_test.ts
@@ -1,0 +1,42 @@
+// =============================================================================
+// File        : util_test.ts
+// Author      : yukimemi
+// Last Change : 2024/11/02 15:26:35.
+// =============================================================================
+
+import { assertEquals } from "jsr:@std/assert@1.0.6";
+
+import { convertUrl } from "./util.ts";
+
+Deno.test({
+  name: "convertUrl with repository path",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const actual = convertUrl("vim-jp/vimdoc-ja");
+    const expected = "https://github.com/vim-jp/vimdoc-ja";
+    assertEquals(actual, expected);
+  },
+});
+
+Deno.test({
+  name: "convertUrl with https URL",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const actual = convertUrl("https://github.com/vim-jp/vimdoc-ja");
+    const expected = "https://github.com/vim-jp/vimdoc-ja";
+    assertEquals(actual, expected);
+  },
+});
+
+Deno.test({
+  name: "convertUrl with git URL",
+  sanitizeOps: false,
+  sanitizeResources: false,
+  fn: async () => {
+    const actual = convertUrl("git://github.com/vim-jp/vimdoc-ja");
+    const expected = "git://github.com/vim-jp/vimdoc-ja";
+    assertEquals(actual, expected);
+  },
+});

--- a/util_test.ts
+++ b/util_test.ts
@@ -4,7 +4,7 @@
 // Last Change : 2024/11/02 15:32:24.
 // =============================================================================
 
-import { assertEquals } from "jsr:@std/assert@1.0.6";
+import { assertEquals } from "jsr:@std/assert@1.0.7";
 
 import { convertUrl } from "./util.ts";
 

--- a/util_test.ts
+++ b/util_test.ts
@@ -1,7 +1,7 @@
 // =============================================================================
 // File        : util_test.ts
 // Author      : yukimemi
-// Last Change : 2024/11/02 15:26:35.
+// Last Change : 2024/11/02 15:32:24.
 // =============================================================================
 
 import { assertEquals } from "jsr:@std/assert@1.0.6";
@@ -12,7 +12,7 @@ Deno.test({
   name: "convertUrl with repository path",
   sanitizeOps: false,
   sanitizeResources: false,
-  fn: async () => {
+  fn: () => {
     const actual = convertUrl("vim-jp/vimdoc-ja");
     const expected = "https://github.com/vim-jp/vimdoc-ja";
     assertEquals(actual, expected);
@@ -23,7 +23,7 @@ Deno.test({
   name: "convertUrl with https URL",
   sanitizeOps: false,
   sanitizeResources: false,
-  fn: async () => {
+  fn: () => {
     const actual = convertUrl("https://github.com/vim-jp/vimdoc-ja");
     const expected = "https://github.com/vim-jp/vimdoc-ja";
     assertEquals(actual, expected);
@@ -34,7 +34,7 @@ Deno.test({
   name: "convertUrl with git URL",
   sanitizeOps: false,
   sanitizeResources: false,
-  fn: async () => {
+  fn: () => {
     const actual = convertUrl("git://github.com/vim-jp/vimdoc-ja");
     const expected = "git://github.com/vim-jp/vimdoc-ja";
     assertEquals(actual, expected);


### PR DESCRIPTION
Fix destination calculation using url, not `plug.url`. #64 

The plugin should use `info.url` when calculating the destination path, not `plug.url`. This change ensures that the destination path is calculated correctly even when the URL does not contain a hostname or pathname.

This change also fixes a bug where the destination path was calculated incorrectly when the URL contained a query string or fragment.
