### PR TITLE
fix(plugin): Enhance URL handling and fix plugin destination path (is…

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@yukimemi/dvpm",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "exports": "./mod.ts",
   "tasks": {
     "check": "deno check ./**/*.ts",

--- a/plugin.ts
+++ b/plugin.ts
@@ -1,7 +1,7 @@
 // =============================================================================
 // File        : plugin.ts
 // Author      : yukimemi
-// Last Change : 2025/01/02 01:35:10.
+// Last Change : 2025/01/26 16:31:12.
 // =============================================================================
 
 import * as fn from "jsr:@denops/std@7.4.0/function";
@@ -13,7 +13,7 @@ import { Git } from "./git.ts";
 import { PlugInfoSchema, PlugOptionSchema, PlugSchema } from "./types.ts";
 import { Result } from "npm:result-type-ts@2.2.0";
 import { Semaphore } from "jsr:@lambdalisue/async@2.1.1";
-import { cmdOutToString, convertUrl, executeFile, getExecuteStr } from "./util.ts";
+import { cmdOutToString, convertUrl, executeFile, getExecuteStr, parseUrl } from "./util.ts";
 import { echo, execute } from "jsr:@denops/std@7.4.0/helper";
 import { exists, expandGlob } from "jsr:@std/fs@1.0.10";
 import { logger } from "./logger.ts";
@@ -54,8 +54,8 @@ export class Plugin {
       logger().debug(`[create] set dst to ${p.plug.dst}`);
       p.info.dst = z.string().parse(await fn.expand(p.denops, p.plug.dst));
     } else {
-      const url = new URL(p.info.url);
-      p.info.dst = path.join(option.base, url.hostname, url.pathname);
+      const { hostname, pathname } = parseUrl(p.info.url);
+      p.info.dst = path.join(option.base, hostname, pathname);
     }
     p.info.clone = await p.is(p.info.clone);
     p.info.enabled = await p.is(p.info.enabled) && p.info.clone &&

--- a/util.ts
+++ b/util.ts
@@ -1,7 +1,7 @@
 // =============================================================================
 // File        : util.ts
 // Author      : yukimemi
-// Last Change : 2024/12/01 18:32:26.
+// Last Change : 2025/01/26 16:43:06.
 // =============================================================================
 
 import * as fn from "jsr:@denops/std@7.4.0/function";
@@ -92,8 +92,27 @@ export function cmdOutToString(cmdout: Uint8Array): string[] {
  * Convert url
  */
 export function convertUrl(url: string): string {
-  if (url.startsWith("https://") || url.startsWith("git")) {
+  const hasProtocol = /^(https?:\/\/|git:\/\/|ssh:\/\/|git@)/.test(url);
+  if (hasProtocol) {
     return url;
+  } else {
+    return `https://github.com/${url}`;
   }
-  return `https://github.com/${url}`;
+}
+
+/**
+ * Parse url
+ */
+export function parseUrl(url: string): { hostname: string; pathname: string } {
+  if (url.startsWith("git@")) {
+    url = url.replace(":", "/").replace("git@", "https://");
+  }
+  if (url.endsWith(".git")) {
+    url = url.slice(0, -4);
+  }
+  const urlObj = new URL(url);
+  return {
+    hostname: urlObj.hostname,
+    pathname: urlObj.pathname,
+  };
 }


### PR DESCRIPTION
…sue#78)

This commit improves the plugin's ability to handle different URL formats, including shorthand, http, https, git, and ssh URLs. It introduces a `parseUrl` function to extract the hostname and pathname from a URL, ensuring accurate destination path generation. The commit also includes test cases for various URL types and fixes a bug related to the plugin's destination path.

- Update `deno.json` version to `6.1.1`.
- Update plugin.ts to use `parseUrl` instead of `new URL` for getting `hostname` and `pathname`
- Add test cases for various types of URLs in `plugin_test.ts`
- Add `parseUrl` function in `util.ts`
- Update `Last Change` in `plugin.ts`, `plugin_test.ts` and `util.ts`