### PR TITLE
feat: add cache.init and cache.initFile hooks for pre-runtimepath execution

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -13,7 +13,11 @@
       "Bash(gh run:*)",
       "Bash(python -c \"import sys,json; comments=json.load\\(sys.stdin\\); [print\\(f'--- {c[\\\\\"path\\\\\"]}:{c[\\\\\"line\\\\\"]}\\\\n{c[\\\\\"body\\\\\"]}\\\\n'\\) for c in comments]\")",
       "Bash(python -c \"import sys,json; comments=json.load\\(sys.stdin\\); [print\\(c['id']\\) for c in comments]\")",
-      "Bash(python -c ':*)"
+      "Bash(python -c ':*)",
+      "Bash(deno publish:*)",
+      "Bash(DENOPS_TEST_VIM_EXECUTABLE=\"\" deno test -A --no-check tests/lazy_keys_test.ts tests/expr_map_test.ts)",
+      "Bash(DENOPS_TEST_VIM_EXECUTABLE=\"\" deno run -A scripts/test_runner.ts tests/lazy_keys_test.ts tests/expr_map_test.ts)",
+      "Bash(jj st:*)"
     ]
   }
 }

--- a/plugin.ts
+++ b/plugin.ts
@@ -175,7 +175,9 @@ export class Plugin {
       cacheStr.push(await getExecuteStr(this.denops, this.info.cache.initFile));
     }
     cacheStr.push(`set runtimepath+=${this.info.dst}`);
-    cacheStr.push(this.info.cache?.before || "");
+    if (this.info.cache?.before) {
+      cacheStr.push(this.info.cache.before);
+    }
     if (this.info.cache?.beforeFile) {
       cacheStr.push(await getExecuteStr(this.denops, this.info.cache.beforeFile));
     }
@@ -188,7 +190,9 @@ export class Plugin {
     if (this.info.cache?.afterFile) {
       cacheStr.push(await getExecuteStr(this.denops, this.info.cache.afterFile));
     }
-    cacheStr.push(this.info.cache?.after || "");
+    if (this.info.cache?.after) {
+      cacheStr.push(this.info.cache.after);
+    }
     return cacheStr.join("\n");
   }
 

--- a/plugin.ts
+++ b/plugin.ts
@@ -117,6 +117,7 @@ export class Plugin {
   private async initCache() {
     this.info.cache.enabled = await this.is(this.info.cache.enabled);
     if (
+      this.info.cache?.init || this.info.cache?.initFile ||
       this.info.cache?.before || this.info.cache?.after || this.info.cache?.beforeFile ||
       this.info.cache?.afterFile
     ) {
@@ -166,7 +167,14 @@ export class Plugin {
       return "";
     }
     this.info.isCache = true;
-    const cacheStr = [`set runtimepath+=${this.info.dst}`];
+    const cacheStr: string[] = [];
+    if (this.info.cache?.init) {
+      cacheStr.push(this.info.cache.init);
+    }
+    if (this.info.cache?.initFile) {
+      cacheStr.push(await getExecuteStr(this.denops, this.info.cache.initFile));
+    }
+    cacheStr.push(`set runtimepath+=${this.info.dst}`);
     cacheStr.push(this.info.cache?.before || "");
     if (this.info.cache?.beforeFile) {
       cacheStr.push(await getExecuteStr(this.denops, this.info.cache.beforeFile));

--- a/tests/plugin_test.ts
+++ b/tests/plugin_test.ts
@@ -7,7 +7,7 @@
 import * as path from "@std/path";
 import { test } from "@denops/test";
 import { Plugin } from "../plugin.ts";
-import { assertEquals } from "@std/assert";
+import { assert, assertEquals } from "@std/assert";
 
 test({
   mode: "all",
@@ -124,5 +124,35 @@ test({
     // 4. No dst, but explicit clean: false -> should be false
     const p4 = await Plugin.create(denops, { url: "owner/p4", clean: false }, option);
     assertEquals(p4.info.clean, false, "p4: should be false (explicit clean)");
+  },
+});
+
+test({
+  mode: "all",
+  name: "Plugin cache() generates script in correct order (init before runtimepath)",
+  fn: async (denops) => {
+    const base = await Deno.makeTempDir();
+    const option = { base, profiles: [], logarg: [], clean: false };
+
+    const plugin = await Plugin.create(denops, {
+      url: "owner/repo",
+      cache: {
+        init: "let g:cache_init = 1",
+        before: "let g:cache_before = 1",
+        after: "let g:cache_after = 1",
+      },
+    }, option);
+
+    const script = await plugin.cache();
+    const lines = script.split("\n").filter(Boolean);
+
+    const initIdx = lines.findIndex((l) => l.includes("cache_init"));
+    const rtpIdx = lines.findIndex((l) => l.startsWith("set runtimepath+="));
+    const beforeIdx = lines.findIndex((l) => l.includes("cache_before"));
+    const afterIdx = lines.findIndex((l) => l.includes("cache_after"));
+
+    assert(initIdx < rtpIdx, "init must come before runtimepath");
+    assert(rtpIdx < beforeIdx, "runtimepath must come before before");
+    assert(beforeIdx < afterIdx, "before must come before after");
   },
 });

--- a/tests/plugin_test.ts
+++ b/tests/plugin_test.ts
@@ -151,8 +151,42 @@ test({
     const beforeIdx = lines.findIndex((l) => l.includes("cache_before"));
     const afterIdx = lines.findIndex((l) => l.includes("cache_after"));
 
+    assert(initIdx >= 0, "cache_init should be present in script");
+    assert(rtpIdx >= 0, "set runtimepath should be present in script");
+    assert(beforeIdx >= 0, "cache_before should be present in script");
+    assert(afterIdx >= 0, "cache_after should be present in script");
+
     assert(initIdx < rtpIdx, "init must come before runtimepath");
     assert(rtpIdx < beforeIdx, "runtimepath must come before before");
     assert(beforeIdx < afterIdx, "before must come before after");
+  },
+});
+
+test({
+  mode: "all",
+  name: "Plugin cache() places initFile content before runtimepath",
+  fn: async (denops) => {
+    const base = await Deno.makeTempDir();
+    const option = { base, profiles: [], logarg: [], clean: false };
+
+    const initFile = await Deno.makeTempFile({ suffix: ".vim" });
+    // Extract basename to avoid path separator differences across OS/Vim expansion
+    const initFileBase = initFile.replace(/\\/g, "/").split("/").pop()!;
+
+    const plugin = await Plugin.create(denops, {
+      url: "owner/repo",
+      cache: { initFile },
+    }, option);
+
+    const script = await plugin.cache();
+    const lines = script.split("\n").filter(Boolean);
+
+    // getExecuteStr generates `execute 'source' fnameescape('/path/to/file.vim')`
+    const initFileIdx = lines.findIndex((l) => l.includes(initFileBase));
+    const rtpIdx = lines.findIndex((l) => l.startsWith("set runtimepath+="));
+
+    assert(initFileIdx >= 0, "initFile source command should be present in script");
+    assert(rtpIdx >= 0, "set runtimepath should be present in script");
+    assert(initFileIdx < rtpIdx, "initFile source command must come before runtimepath");
   },
 });

--- a/types.ts
+++ b/types.ts
@@ -252,6 +252,8 @@ export type Plug = {
    */
   cache?: {
     enabled?: Bool;
+    init?: string;
+    initFile?: string;
     before?: string;
     after?: string;
     beforeFile?: string;
@@ -310,6 +312,8 @@ const _PlugSchema = type({
   dependencies: type("string[]").default(() => []),
   cache: type({
     enabled: BoolSchema.default(false),
+    "init?": "string",
+    "initFile?": "string",
     "before?": "string",
     "after?": "string",
     "beforeFile?": "string",
@@ -376,6 +380,8 @@ export type PlugInfo = {
   dependencies: string[];
   cache: {
     enabled: Bool;
+    init?: string;
+    initFile?: string;
     before?: string;
     after?: string;
     beforeFile?: string;


### PR DESCRIPTION
## Summary

- Add `cache.init` (Vimscript/Lua string) and `cache.initFile` (file path) fields to the `cache` configuration
- These hooks are executed **before** `set runtimepath+=` in the generated cache script
- Aligns cache hook order with the normal load sequence: `init → runtimepath → before → source → after`
- Setting `cache.init` or `cache.initFile` automatically enables `cache.enabled = true`

## Test plan

- [ ] `deno task check` passes with no type errors
- [ ] New test `Plugin cache() generates script in correct order (init before runtimepath)` passes on nvim
- [ ] Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Plugins can now configure cache initialization via new cache.init and cache.initFile options; initialization runs before runtime path setup.

* **Tests**
  * Added tests validating cache script ordering, ensuring init executes before runtime path updates and other cache steps.

* **Chores**
  * Expanded local permissions allowlist to include additional command patterns for Deno and jj tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->