### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,14 +1,14 @@
 preset = "github.com/yukimemi/pj-presets:denops"
-applied_at = "2026-08-15T09:51:58.4664562Z"
+applied_at = "2026-08-19T03:31:02.761793678Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
-rev = "1a7c2be1758fd01c875b3d503201145f64df42ea"
+rev = "27e4c1fe27ce44731a04bf0d55590fa6a0db27d4"
 version = "0.14.0"
 
 [[templates]]
 source = "github.com/yukimemi/pj-denops"
-rev = "3a2578879833e30e07507ac826c5965fd528a391"
+rev = "81beb1e48d13ac8eeb8cc314da712fe3434d7555"
 version = "0.1.0"
 
 [files.".agents/skills/renri/SKILL.md"]
@@ -76,6 +76,7 @@ once_applied = true
 content_hash = "2ada1cf4347db9e98fadd67ca72cd9e29042c5bf6ab719d666b5d71f97663e81"
 
 [files."renovate.json"]
+content_hash = "c65a80db64e96d0d8dc91796e2d7275619c7b249a6aefe236d8b125524cacebd"
 once_applied = true
 
 [files."renri.toml"]

--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "github>yukimemi/pj-base",
-    ":prHourlyLimitNone",
-    ":prConcurrentLimitNone"
+    "github>yukimemi/pj-denops"
   ]
 }


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project template revisions and application metadata.
  * Updated automated dependency maintenance configuration to use the latest shared preset.
  * Added configuration integrity tracking for dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->