### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.github/workflows/kata-apply.yml
+++ b/.github/workflows/kata-apply.yml
@@ -17,7 +17,10 @@ name: kata-apply
 #
 # Output: a PR (single rolling branch `kata-apply/auto`) with the
 # rendered-file diff. Auto-merged when CI passes — if CI fails,
-# the PR stays open for human review.
+# the PR stays open for human review. Auto-merge can also fail to
+# arm at all (see the last step), whether because the repo has no
+# required checks or because none had registered yet; the PR then
+# stays open, which is the safe default.
 #
 # Source: yukimemi/pj-base. Filename carries `.tera` so kata
 # Tera-renders the file at apply time (substituting
@@ -90,15 +93,56 @@ jobs:
           body: |
             Automated `kata update + apply` (daily schedule + manual dispatch).
 
-            Auto-merged when CI passes; left open if CI fails.
+            Auto-merged when CI passes; left open if CI fails — or if
+            auto-merge couldn't be armed (no required checks, or none
+            had registered yet when this PR was opened).
 
             <!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->
           author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
 
+      # Arm auto-merge so the PR lands by itself once the consumer's
+      # required checks go green.
+      #
+      # Deliberately tolerant of failure. GitHub rejects the
+      # `enablePullRequestAutoMerge` mutation when the PR is ALREADY
+      # mergeable — nothing left to wait on — and `gh pr merge
+      # --auto` exits 1 with
+      #   GraphQL: Pull request Pull request is in clean status
+      #   (enablePullRequestAutoMerge)
+      # Two situations produce that state: a default branch with no
+      # required status checks, permanently; or, transiently, this
+      # step firing a second or two after `create-pull-request`
+      # opens the PR, before the first check has registered. The
+      # second is a race, so the same repo can fail one run and
+      # succeed the next — yukimemi/hakari did exactly that within
+      # the hour (run 32610568604 failed, run 32612382813 armed
+      # fine) with its branch protection unchanged (absent)
+      # throughout. Either way, a red scheduled job that means
+      # nothing trains people to ignore the one that does.
+      #
+      # No fallback to an unconditional `gh pr merge --squash`: a repo
+      # with no required checks has no automated confidence to merge
+      # on. The very hakari PR that surfaced this carried three silent
+      # reverts of consumer-owned config; a human caught them. Leaving
+      # the PR open IS the correct outcome here, not a degraded one.
+      #
+      # Nor is the cause worth discriminating: gh reports every
+      # failure as a bare exit 1 with no machine-readable cause, so
+      # telling the two apart would mean matching on the error text
+      # — brittle against gh/API wording drift — and against a race
+      # the verdict would be about timing, not configuration. The
+      # step tolerates any arming failure and annotates it instead;
+      # gh's own stderr stays in the log, and the PR is visible on
+      # the repo either way.
       - name: Enable auto-merge
         if: steps.cpr.outputs.pull-request-number != ''
         env:
           GH_TOKEN: ${{ secrets.KATA_APPLY_TOKEN }}
+          PR: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
-          gh pr merge --auto --squash ${{ steps.cpr.outputs.pull-request-number }}
+          if gh pr merge --auto --squash "$PR"; then
+            echo "Auto-merge armed for PR #${PR}; it will land once required checks pass."
+            exit 0
+          fi
+          echo "::notice::Auto-merge could not be armed for PR #${PR} (see the gh error above; GitHub refuses to arm auto-merge on an already-mergeable PR — either the repo has no required status checks, or none had registered yet in the seconds since the PR was opened). Leaving the PR open for human review."

--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,10 +1,10 @@
 preset = "github.com/yukimemi/pj-presets:denops"
-applied_at = "2026-08-19T03:31:02.761793678Z"
+applied_at = "2026-08-23T03:33:23.808159653Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
-rev = "8217f1a99c55240c7337f40b8afb35d9e9232499"
-version = "0.14.0"
+rev = "0424dfa03771babdeca3c22f08fe003f2811f820"
+version = "0.16.0"
 
 [[templates]]
 source = "github.com/yukimemi/pj-denops"
@@ -42,13 +42,13 @@ content_hash = "e018b9c422cac8cb57d832c4100697a56bbd4b5f5a9a2abd6c803149665525a7
 content_hash = "a4e49b9b5141212cff2828bea086762db0bd7a6fd2c4a4a132fe12f5c18dcaf2"
 
 [files.".github/workflows/kata-apply.yml"]
-content_hash = "62bd9b21a8b7257762d06feefbd3d4595cadfdf01dbde2e67a03521fc4b09efc"
+content_hash = "c70c39b08f0e914a44c1dc6c558b3ce2439933fbd64c51674fe64dbc640f02bc"
 
 [files.".gitignore"]
 content_hash = "4bebd1c3417c33f9d1c51f011694f6d82b098bbb1a5a102ba56e97ab01a866ef"
 
 [files.".kata/vars.toml"]
-content_hash = "393b2b94540e792790ef9357e46e5bc259eb3064605794ca2373ae458999cb23"
+content_hash = "8e573305bc9b45b40e4c4c24c0da7728771a12d81c4c1631d6e35f25a189cf84"
 once_applied = true
 
 [files."AGENTS.md"]

--- a/.kata/vars.toml
+++ b/.kata/vars.toml
@@ -29,7 +29,7 @@ checkout = "v7.0.1"
 # renovate: datasource=github-tags depName=peter-evans/create-pull-request
 create_pull_request = "v8.1.1"
 # renovate: datasource=github-tags depName=anthropics/claude-code-action
-claude_code_action = "v1"
+claude_code_action = "v1.0.195"
 # renovate: datasource=github-tags depName=denoland/setup-deno
 deno_setup = "v2"
 # renovate: datasource=github-tags depName=rhysd/action-setup-vim

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,13 +13,19 @@ here so each tool's auto-load behaviour still finds something.
   - Exception: trivial typo / whitespace / docs wording fixes.
 - Branch names: `feat/...`, `fix/...`, `chore/...`.
 - **PR titles + bodies in English. Commit messages in English.**
-- **Releases are PR-driven, tagging is automatic.** Bump
-  `[workspace.package].version` (workspace) or `[package].version`
-  (single crate) in a `chore/release-vX.Y.Z` PR. On merge to `main`,
-  `.github/workflows/auto-tag.yml` (kata-managed) detects the bump,
-  pushes the `vX.Y.Z` tag, and that tag fires `release.yml` for
-  binary builds + crates.io publish. **Do not run `git tag` by
-  hand** — the bot tag will collide and the manual push fails.
+- **Releases are PR-driven and tagging is automatic** — in repos that
+  ship a release pipeline. Bump the version in the project's own
+  manifest in a `chore/release-vX.Y.Z` PR; on merge to `main` the
+  language layer's `auto-tag.yml` detects the bump, pushes the
+  `vX.Y.Z` tag, and that tag is what fires `release.yml`. **Do not run
+  `git tag` by hand** — the bot tag will collide and the manual push
+  fails. The specifics belong to the layers shipping those two
+  workflows, which are not the same layer: `kata:agents:rust:*` for
+  which file holds the version and for `auto-tag.yml`,
+  `kata:agents:rust-{cli,lib}:*` for what `release.yml` builds and
+  publishes. A repo with no `auto-tag.yml` has no release pipeline at
+  all: nothing tags, and the version field in its manifest may well
+  be decoration.
 
 ### PR review cycle
 
@@ -207,11 +213,52 @@ templates — the bytes between `<!-- kata:*:begin -->` and
 listed in `.kata/applied.toml`. **Editing those bytes locally
 won't survive the next `kata apply`** — push the change to the
 upstream template repo (`yukimemi/pj-base` / `yukimemi/pj-rust` /
-…) instead. The marker scopes are layered:
+…) instead.
 
-- `kata:agents:base:*` — language-agnostic conventions (this section).
-- `kata:agents:rust:*` — added when `pj-rust` applies.
-- `kata:agents:rust-cli:*` — added when `pj-rust-cli` applies.
+The marker scopes are layered, one per applied layer:
+`kata:agents:base:*` is this section, and each layer adds its own
+(`kata:agents:rust:*`, `kata:agents:rust-cli:*`,
+`kata:agents:pnpm:*`, `kata:agents:firebase:*`, …). Which ones apply
+*here* is a grep away: `<!-- kata:` in this file.
+
+### This project's own conventions
+
+Everything a layer ships is generic by construction: it describes the
+stack the template assumed, not what this repo grew into. **Bytes
+outside every marker pair are yours and survive `kata apply`** — so
+project-specific conventions belong in a section of their own, outside
+the markers (conventionally at the end of the file; if a later layer
+appends its block below yours, no matter — kata only ever rewrites
+between its own markers). Same mechanism as the `.gitignore` /
+`.gitattributes` blocks.
+
+Write those conventions down there rather than leaving them in one
+agent's head, in commit archaeology, or in a README the agent will not
+read. What earns a line:
+
+- **Any layer default that does not hold here.** A layer states its
+  assumption flatly ("Hosting is the primary target", "these rules are
+  a placeholder to replace"). When the project has diverged, say so and
+  say why — the layer's text keeps asserting the opposite on every
+  apply, and an agent that only reads the blocks will act on it.
+- **Facts duplicated across files with no compiler in between** — an
+  address or a path that appears in code *and* in a rules/config file
+  that cannot import it, a timeout that has to stay inside another
+  timeout. List every copy, so the next edit finds them all.
+- **kata-shipped files this project deleted on purpose**, together with
+  the `once_applied = true` line in `.kata/applied.toml` that keeps
+  them deleted. Otherwise someone helpfully restores one.
+- **Shapes the runtime forces but no tool checks** — an export form a
+  platform requires, import specifiers that must (or must not) carry a
+  file extension, a directory whose contents are reachable by URL.
+- **Invariants that money or access rest on**, naming the file and line
+  that actually enforces them.
+- **Which language the code speaks versus what a user reads**, when the
+  two differ.
+
+A repo whose `AGENTS.md` is nothing but kata blocks is a repo where
+every agent re-derives all of that from scratch — and gets the layer
+defaults wrong the same way each time.
 <!-- kata:agents:base:end -->
 <!-- kata:agents:denops:begin -->
 ### Denops plugin workflow


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails.

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved automated pull request handling so auto-merge failures no longer cause the workflow to fail.
  - Pull requests remain open safely when auto-merge cannot be enabled, with a clear notice explaining the situation.
  - Prevented unnecessary fallback merges when required checks are unavailable or have not yet registered.

- **Documentation**
  - Clarified release procedures, workflow ownership, versioning guidance, and managed documentation conventions.
  - Added guidance against manually creating release tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->