### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.github/workflows/apm-bump.yml
+++ b/.github/workflows/apm-bump.yml
@@ -122,15 +122,52 @@ jobs:
           body: |
             Automated `apm install --update` (weekly schedule + manual dispatch).
 
-            Auto-merged when CI passes; left open if CI fails.
+            Auto-merged when CI passes; left open if CI fails — or if
+            auto-merge couldn't be armed (no required checks, or none
+            had registered yet when this PR was opened).
 
             <!-- pj-base ships this workflow; see yukimemi/pj-base -->
           author: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
           committer: "github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
 
+      # Arm auto-merge so the PR lands by itself once the consumer's
+      # required checks go green.
+      #
+      # Deliberately tolerant of failure, same reasoning as
+      # kata-apply.yml.tera's identical step: GitHub rejects the
+      # `enablePullRequestAutoMerge` mutation when the PR is ALREADY
+      # mergeable — nothing left to wait on — and `gh pr merge
+      # --auto` exits 1 with
+      #   GraphQL: Pull request Pull request is in clean status
+      #   (enablePullRequestAutoMerge)
+      # Two situations produce that state here: a consumer repo with
+      # no required status checks, permanently; or, transiently,
+      # this step firing before the first check has registered on
+      # the just-opened `apm-bump/auto` PR — a race, so the same
+      # repo can fail one weekly run and succeed the next with its
+      # branch protection unchanged.
+      #
+      # No fallback to an unconditional `gh pr merge --squash`: a
+      # repo with no required checks has no automated confidence to
+      # merge an apm.lock.yaml bump on, and leaving the PR open for
+      # human review is the correct outcome here, not a degraded one.
+      #
+      # Nor is the cause worth discriminating: gh reports every
+      # failure as a bare exit 1 with no machine-readable cause, so
+      # telling the two apart would mean matching on error text —
+      # brittle against gh/API wording drift — against a race whose
+      # verdict is about timing, not configuration. The step
+      # tolerates any arming failure and annotates it instead; gh's
+      # own stderr stays in the log, and the PR is visible on the
+      # repo either way.
       - name: Enable auto-merge
         if: steps.cpr.outputs.pull-request-number != ''
         env:
           GH_TOKEN: ${{ secrets.KATA_APPLY_TOKEN }}
+          PR: ${{ steps.cpr.outputs.pull-request-number }}
         run: |
-          gh pr merge --auto --squash ${{ steps.cpr.outputs.pull-request-number }}
+          if gh pr merge --auto --squash "$PR"; then
+            echo "Auto-merge armed for PR #${PR}; it will land once required checks pass."
+            exit 0
+          fi
+          echo "::notice::Auto-merge could not be armed for PR #${PR} (see the gh error above; GitHub refuses to arm auto-merge on an already-mergeable PR — either the repo has no required status checks, or none had registered yet in the seconds since the PR was opened). Leaving the PR open for human review."

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -143,7 +143,21 @@ jobs:
           # (anthropics/claude-code-action#1236). The App token the
           # action exchanges covers API calls, not that first fetch.
 
-      - uses: anthropics/claude-code-action@v1
+      # No-op on non-pnpm consumers (Rust, Bun, or anything else) —
+      # gated on pnpm-lock.yaml so this only fires when a pj-pnpm
+      # layer is actually composed in. Corepack ships with the
+      # runner's preinstalled Node.js and reads package.json's
+      # `packageManager` field to materialize the exact pinned pnpm
+      # version, so no extra action or version pin is needed here.
+      # Deliberately not `pnpm/action-setup`: this layer (pj-base) is
+      # language-agnostic and has no `vars.actions.pnpm_action_setup`
+      # pin available — that's seeded only by the optional pj-pnpm
+      # layer's vars.pnpm.toml, and referencing it unconditionally
+      # here would break Rust-only consumers that never seed it.
+      - if: hashFiles('pnpm-lock.yaml') != ''
+        run: corepack enable
+
+      - uses: anthropics/claude-code-action@v1.0.195
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Tracking comment with progress checkboxes; also pulls
@@ -164,13 +178,14 @@ jobs:
             - Tests: coverage for the changed behaviour
 
             You can run this project's own verification commands
-            (`cargo make check` / `cargo test` / `bun test` and the
-            like). Use them when a finding is worth confirming — a
-            reviewer who ran the test is worth more than one who
-            inferred from the diff — and say which you ran. Keep it
-            targeted: a cold full build costs minutes, so reach for
-            the narrowest command that settles the question, and
-            don't build at all for findings the diff already proves.
+            (`cargo make check` / `cargo test` / `bun test` /
+            `pnpm test` and the like). Use them when a finding is
+            worth confirming — a reviewer who ran the test is worth
+            more than one who inferred from the diff — and say
+            which you ran. Keep it targeted: a cold full build
+            costs minutes, so reach for the narrowest command that
+            settles the question, and don't build at all for
+            findings the diff already proves.
 
             Post specific issues as inline comments on the relevant
             lines. Use one top-level comment for the overall
@@ -210,4 +225,4 @@ jobs:
           # rest of this list bounds intent rather than capability.
           # That is the accepted trade; the stdin path is not.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(cargo make:*),Bash(cargo test:*),Bash(cargo clippy:*),Bash(cargo check:*),Bash(cargo fmt:*),Bash(bun install:*),Bash(bun test:*),Bash(bun run build:*),Bash(bun run test:*),Bash(bun run lint:*),Bash(bun run check:*),Bash(bun run typecheck:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(cargo make:*),Bash(cargo test:*),Bash(cargo clippy:*),Bash(cargo check:*),Bash(cargo fmt:*),Bash(bun install:*),Bash(bun test:*),Bash(bun run build:*),Bash(bun run test:*),Bash(bun run lint:*),Bash(bun run check:*),Bash(bun run typecheck:*),Bash(pnpm install:*),Bash(pnpm build:*),Bash(pnpm lint:*),Bash(pnpm test:*)"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,6 +21,21 @@ name: claude
 #
 # `when = "always"` (in template.toml): every consumer wants the
 # same responder; fixes to the workflow flow automatically.
+#
+# No `pull_request_review` trigger, and the reason is a merge
+# blocker masquerading as a responder that did not fire. Replying
+# to an inline review comment — `/pulls/{n}/comments/{id}/replies`,
+# which is exactly the AGENTS.md "reply to reviewers in each
+# thread" convention — makes GitHub create a NEW review whose
+# summary body is EMPTY and fires `pull_request_review` with
+# `review.body == ""`. The `@claude` sits in the comment, not the
+# summary, so the job's condition cannot see it; the job skips,
+# and a SKIPPED check run named "claude" then blocks the merge
+# under branch protection until an admin bypasses it. Observed on
+# yukimemi/hakari#18. In-thread replies are already caught by
+# `pull_request_review_comment` above, so dropping the review event
+# loses nothing for that flow. The only loss is an `@claude` placed
+# in a review *summary*, which is not a documented pattern.
 
 on:
   issue_comment:
@@ -29,8 +44,6 @@ on:
     types: [created]
   issues:
     types: [opened, assigned]
-  pull_request_review:
-    types: [submitted]
 
 permissions:
   # contents/pull-requests/issues write: Claude may push fix
@@ -73,12 +86,10 @@ jobs:
     if: |
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
                github.event.comment.author_association ||
-               github.event.review.author_association ||
                github.event.issue.author_association) &&
       (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
         (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
       )
     runs-on: ubuntu-latest
@@ -121,7 +132,21 @@ jobs:
           # (anthropics/claude-code-action#1236). The App token the
           # action exchanges covers API calls, not that first fetch.
 
-      - uses: anthropics/claude-code-action@v1
+      # No-op on non-pnpm consumers (Rust, Bun, or anything else) —
+      # gated on pnpm-lock.yaml so this only fires when a pj-pnpm
+      # layer is actually composed in. Corepack ships with the
+      # runner's preinstalled Node.js and reads package.json's
+      # `packageManager` field to materialize the exact pinned pnpm
+      # version, so no extra action or version pin is needed here.
+      # Deliberately not `pnpm/action-setup`: this layer (pj-base) is
+      # language-agnostic and has no `vars.actions.pnpm_action_setup`
+      # pin available — that's seeded only by the optional pj-pnpm
+      # layer's vars.pnpm.toml, and referencing it unconditionally
+      # here would break Rust-only consumers that never seed it.
+      - if: hashFiles('pnpm-lock.yaml') != ''
+        run: corepack enable
+
+      - uses: anthropics/claude-code-action@v1.0.195
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # The same list `claude-review.yml.tera` carries, and for the
@@ -138,4 +163,4 @@ jobs:
           # test code, so this list bounds intent rather than
           # capability — which is why the job now checks who is asking.
           claude_args: |
-            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(cargo make:*),Bash(cargo test:*),Bash(cargo clippy:*),Bash(cargo check:*),Bash(cargo fmt:*),Bash(bun install:*),Bash(bun test:*),Bash(bun run build:*),Bash(bun run test:*),Bash(bun run lint:*),Bash(bun run check:*),Bash(bun run typecheck:*)"
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(cargo make:*),Bash(cargo test:*),Bash(cargo clippy:*),Bash(cargo check:*),Bash(cargo fmt:*),Bash(bun install:*),Bash(bun test:*),Bash(bun run build:*),Bash(bun run test:*),Bash(bun run lint:*),Bash(bun run check:*),Bash(bun run typecheck:*),Bash(pnpm install:*),Bash(pnpm build:*),Bash(pnpm lint:*),Bash(pnpm test:*)"

--- a/.github/workflows/kata-apply.yml
+++ b/.github/workflows/kata-apply.yml
@@ -61,6 +61,8 @@ jobs:
       - uses: actions/checkout@v7.0.1
         with:
           token: ${{ secrets.KATA_APPLY_TOKEN }}
+          # Don't leave KATA_APPLY_TOKEN in the local git credential helper for the "Install kata" step (downloads and runs the untrusted `kata` binary from GitHub's `latest` release) to read: kata update/apply never push, and the later create-pull-request / gh pr merge steps each bring their own explicit token.
+          persist-credentials: false
 
       - name: Install kata
         run: |

--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,10 +1,10 @@
 preset = "github.com/yukimemi/pj-presets:denops"
-applied_at = "2026-08-23T03:33:23.808159653Z"
+applied_at = "2026-08-24T03:34:43.583421457Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
-rev = "0424dfa03771babdeca3c22f08fe003f2811f820"
-version = "0.16.0"
+rev = "d32d2b5417b0e999bdefd311c21faaee18f2f1aa"
+version = "0.18.0"
 
 [[templates]]
 source = "github.com/yukimemi/pj-denops"
@@ -24,7 +24,7 @@ content_hash = "486c974de88903113ed99b4e643432b7050e88f1031276f5263e8da7b43fe11e
 content_hash = "6d380d1ecc2f882c2011429d548a6f3c774b74f0c757d884453e4667172acc2a"
 
 [files.".github/workflows/apm-bump.yml"]
-content_hash = "f1cf3615e0f5ff443860722da8d7f74530eaa37e755e65f4392a0c25cd83917e"
+content_hash = "0ac5ed2847ab6e1041e34209dcc2396a582722ea9537d03bd950e1db1851a4b7"
 
 [files.".github/workflows/automerge.yml"]
 once_applied = true
@@ -33,16 +33,16 @@ once_applied = true
 content_hash = "8ec238516165f4c03c8cb08216b19afe379339dd4792406660d9e96ed9c23cf2"
 
 [files.".github/workflows/claude-review.yml"]
-content_hash = "4589425f4f2dd857f64116c2a8e0ae8746df423dd4cdf1de6c7e582b13fe245f"
+content_hash = "4a8e47aabb3cdf2a59030d5194467022f0efb53bb1819d4495752020d10be773"
 
 [files.".github/workflows/claude.yml"]
-content_hash = "e018b9c422cac8cb57d832c4100697a56bbd4b5f5a9a2abd6c803149665525a7"
+content_hash = "c83b52d5f483fdec494028b932facf98018500ce757718cc2e3703328688f5ad"
 
 [files.".github/workflows/deno-update.yml"]
 content_hash = "a4e49b9b5141212cff2828bea086762db0bd7a6fd2c4a4a132fe12f5c18dcaf2"
 
 [files.".github/workflows/kata-apply.yml"]
-content_hash = "c70c39b08f0e914a44c1dc6c558b3ce2439933fbd64c51674fe64dbc640f02bc"
+content_hash = "7000353151b01b5d14cb8f56e314b1a25b020e22bdf5842dcaf5686efb59facb"
 
 [files.".gitignore"]
 content_hash = "4bebd1c3417c33f9d1c51f011694f6d82b098bbb1a5a102ba56e97ab01a866ef"


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails — or if
auto-merge couldn't be armed (no required checks, or none
had registered yet when this PR was opened).

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Workflow Improvements**
  * Auto-merge now handles unavailable CI checks gracefully and keeps pull requests open for review when needed.
  * Automated review workflows now support pnpm projects and provide clearer verification guidance.
  * Review automation uses updated action versions and refined authorization checks.
  * Improved credential handling during automated changes to reduce token persistence risks.
* **Maintenance**
  * Updated automation configuration metadata and template revisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->