### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         id: nvim
         with:
           neovim: true
-          version: "v0.12.4"
+          version: "v0.12.5"
 
       - uses: denoland/setup-deno@v2
 

--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,5 +1,5 @@
 preset = "github.com/yukimemi/pj-presets:denops"
-applied_at = "2026-08-24T03:34:43.583421457Z"
+applied_at = "2026-08-27T05:01:56.855846923Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
@@ -30,7 +30,7 @@ content_hash = "0ac5ed2847ab6e1041e34209dcc2396a582722ea9537d03bd950e1db1851a4b7
 once_applied = true
 
 [files.".github/workflows/ci.yml"]
-content_hash = "8ec238516165f4c03c8cb08216b19afe379339dd4792406660d9e96ed9c23cf2"
+content_hash = "5f6cdf606255f5576c14262803d653858fab963e93c81fcb90357ed8d3bd2dad"
 
 [files.".github/workflows/claude-review.yml"]
 content_hash = "4a8e47aabb3cdf2a59030d5194467022f0efb53bb1819d4495752020d10be773"


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails — or if
auto-merge couldn't be armed (no required checks, or none
had registered yet when this PR was opened).

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Neovim version used in automated testing to v0.12.5.
  * Refreshed internal change-tracking metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->