### PR TITLE
chore(kata): auto-apply

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+# kata:editorconfig:base:begin
+# kata-managed universal EditorConfig rules (yukimemi/pj-base). Normalizes
+# indentation and line endings at edit time so contributors on different
+# editors/OSes converge instead of round-tripping CRLF/LF or mixed indent
+# widths. Companion to `.gitattributes` (`* text=auto eol=lf`, which
+# normalizes at commit time) — this file targets the editor instead.
+# Language layers (pj-rust, ...) append file-type sections via
+# merge-section; see `# kata:editorconfig:*:begin/end` markers in the
+# rendered `.editorconfig`.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+# Markdown: two trailing spaces is a hard line break, not noise.
+[*.md]
+trim_trailing_whitespace = false
+# kata:editorconfig:base:end

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -85,8 +85,8 @@ jobs:
     # `issues`.
     if: |
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'),
-               github.event.comment.author_association ||
-               github.event.issue.author_association) &&
+        github.event.comment.author_association ||
+        github.event.issue.author_association) &&
       (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||

--- a/.kata/applied.toml
+++ b/.kata/applied.toml
@@ -1,9 +1,9 @@
 preset = "github.com/yukimemi/pj-presets:denops"
-applied_at = "2026-08-27T05:01:56.855846923Z"
+applied_at = "2026-08-31T03:30:41.626163899Z"
 
 [[templates]]
 source = "github.com/yukimemi/pj-base"
-rev = "10cd49c09b95af8add4daf71c5151835821cb670"
+rev = "b205d49d8676a2d3b78efa020749b7f012921159"
 version = "0.18.0"
 
 [[templates]]
@@ -16,6 +16,9 @@ once_applied = true
 
 [files.".claude/skills/renri/SKILL.md"]
 once_applied = true
+
+[files.".editorconfig"]
+content_hash = "31dd1c43fbb48cd8380a0fae0780f05d42eef658ea695772c51b4bde291f7438"
 
 [files.".gemini/settings.json"]
 content_hash = "486c974de88903113ed99b4e643432b7050e88f1031276f5263e8da7b43fe11e"
@@ -36,7 +39,7 @@ content_hash = "5f6cdf606255f5576c14262803d653858fab963e93c81fcb90357ed8d3bd2dad
 content_hash = "4a8e47aabb3cdf2a59030d5194467022f0efb53bb1819d4495752020d10be773"
 
 [files.".github/workflows/claude.yml"]
-content_hash = "c83b52d5f483fdec494028b932facf98018500ce757718cc2e3703328688f5ad"
+content_hash = "7bb6c538ec5c2688e01b54e983232fa99f65e24ee16172c4270341345cbdac34"
 
 [files.".github/workflows/deno-update.yml"]
 content_hash = "a4e49b9b5141212cff2828bea086762db0bd7a6fd2c4a4a132fe12f5c18dcaf2"


### PR DESCRIPTION
Automated `kata update + apply` (daily schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails — or if
auto-merge couldn't be armed (no required checks, or none
had registered yet when this PR was opened).

<!-- pj-base ships this workflow; see yukimemi/pj-base#6 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added shared editor settings for consistent indentation, line endings, character encoding, and whitespace handling.
  - Preserved intentional trailing whitespace in Markdown files.
  - Updated workflow formatting without changing its behavior.
  - Refreshed project template application metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->