### PR TITLE
chore(apm): refresh apm.lock.yaml

### DIFF
--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,11 +1,11 @@
 lockfile_version: '1'
-generated_at: '2026-08-31T04:24:43.559100+00:00'
-apm_version: 0.29.0
+generated_at: '2026-09-07T04:24:15.451377+00:00'
+apm_version: 0.29.1
 dependencies:
 - repo_url: yukimemi/renri
   name: renri
   host: github.com
-  resolved_commit: 9b554eb1224ecc0401ad077a7416693b9e8709d2
+  resolved_commit: e66c12ebfe4975bdc92ce4a34d8693675a58fce9
   resolved_ref: main
   version: 0.1.17
   package_type: apm_package
@@ -17,7 +17,7 @@ dependencies:
   deployed_file_hashes:
     .agents/skills/renri/SKILL.md: sha256:b0ef8bb599b5dc116a39dc2d3712dd95c722974b91f109a26263052c8d1090d6
     .claude/skills/renri/SKILL.md: sha256:b0ef8bb599b5dc116a39dc2d3712dd95c722974b91f109a26263052c8d1090d6
-  content_hash: sha256:e6ba4596d4f56aaf86f6d3da1ece18777f2510ab31b5a1312a844df96e1f1581
+  content_hash: sha256:0041b3eaccfad6d80b893818bab5ad45216fcde1ceba912c1d9041a99dc550e7
 deployments:
 - kind: project-relative
   target: claude


### PR DESCRIPTION
Automated `apm install --update` (weekly schedule + manual dispatch).

Auto-merged when CI passes; left open if CI fails — or if
auto-merge couldn't be armed (no required checks, or none
had registered yet when this PR was opened).

<!-- pj-base ships this workflow; see yukimemi/pj-base -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refreshed application package metadata and lockfile information.
  * Updated the recorded package manager version and dependency references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->